### PR TITLE
Initial manifest publishing for CMD

### DIFF
--- a/Manifests/MS/WinCMD-Manifest.xml
+++ b/Manifests/MS/WinCMD-Manifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Company: Microsoft; Product: Windows Command Prompt (cmd.exe) -->
 <AppManifest Id="WindowsCommandPrompt" xmlns="urn:schemas-microsoft-com:windows-defender-application-control">
     <SettingDefinition
         Name="EnableAppControl"

--- a/Manifests/MS/WinCMD-Manifest.xml
+++ b/Manifests/MS/WinCMD-Manifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AppManifest Id="WindowsCommandPrompt" xmlns="urn:schemas-microsoft-com:windows-defender-application-control">
+    <SettingDefinition
+        Name="EnableAppControl"
+        Type="Bool"
+        IgnoreAuditPolicies="false"
+        />
+</AppManifest>


### PR DESCRIPTION
Initial publishing of Microsoft Windows command prompt's Application Settings Manifest. 

One new Application Setting has been added: 

**Name="EnableAppControl"**
Type="Bool"
IgnoreAuditPolicies="false"

The purpose of this application setting is to allow IT admins to opt into the new CMD <--> App Control for Business (WDAC) behavior. Other application manifests will be hosted in this repository as they adopt application settings.

Another PR will be coming soon to populate the associated MD files in this repo. 